### PR TITLE
Add CRUD for Vaults

### DIFF
--- a/API.md
+++ b/API.md
@@ -755,7 +755,7 @@ npm install @eprompt/prompt-engine
 import { generatePrompt, createTemplate } from '@eprompt/prompt-engine';
 
 const template = createTemplate({...});
-const result = generatePrompt(template, context);
+const result = await generatePrompt(template, context);
 ```
 
 ### cURL Examples

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ const template = createTemplate({
 
 // Generate a prompt
 const context = { name: "Alice", platform: "ePrompt" };
-const result = generatePrompt(template, context);
+const result = await generatePrompt(template, context);
 console.log(result.prompt); // "Hello Alice! Welcome to ePrompt."
 
 // Refine a prompt using AI

--- a/prompt-engine/README.md
+++ b/prompt-engine/README.md
@@ -117,7 +117,7 @@ const context = {
   complexity: "beginner"
 };
 
-const result = generatePrompt(template, context);
+const result = await generatePrompt(template, context);
 console.log(result.prompt);
 // Output: Fully formatted prompt with context variables substituted
 
@@ -881,7 +881,7 @@ const context = {
 };
 
 // Generate prompt with full validation
-const result = generatePrompt(template, context);
+const result = await generatePrompt(template, context);
 
 if (result.missingFields.length > 0) {
   console.error("Missing required fields:", result.missingFields);

--- a/prompt-engine/examples/basic-usage.ts
+++ b/prompt-engine/examples/basic-usage.ts
@@ -28,7 +28,7 @@ const greetingContext = {
   features: 'advanced AI tools'
 };
 
-const greetingResult = generatePrompt(greetingTemplate, greetingContext);
+const greetingResult = await generatePrompt(greetingTemplate, greetingContext);
 console.log('Generated Prompt:', greetingResult.prompt);
 console.log('Missing Fields:', greetingResult.missingFields);
 console.log('Context Used:', greetingResult.contextUsed);
@@ -65,7 +65,7 @@ const codeReviewContext = {
   focus_areas: 'error handling and edge cases'
 };
 
-const codeReviewResult = generatePrompt(codeReviewTemplate, codeReviewContext);
+const codeReviewResult = await generatePrompt(codeReviewTemplate, codeReviewContext);
 console.log('Generated Code Review Prompt:');
 console.log(codeReviewResult.prompt);
 console.log('');
@@ -136,7 +136,7 @@ const incompleteContext = {
   // Missing: action, deadline
 };
 
-const incompleteResult = generatePrompt(incompleteTemplate, incompleteContext);
+const incompleteResult = await generatePrompt(incompleteTemplate, incompleteContext);
 console.log('Generated Prompt:', incompleteResult.prompt);
 console.log('Missing Fields:', incompleteResult.missingFields);
 console.log('Has Required Fields:', incompleteResult.metadata?.hasRequiredFields);

--- a/prompt-engine/src/engine/__tests__/e2e.userFlow.test.ts
+++ b/prompt-engine/src/engine/__tests__/e2e.userFlow.test.ts
@@ -30,7 +30,7 @@ describe.skip('e2e: Full user flow (OpenAI)', () => {
       codeSnippet: 'function sum(arr) { return arr.reduce((a, b) => a + b, 0); }'
     };
     // Generate prompt
-    const output = generatePrompt(template, context);
+    const output = await generatePrompt(template, context);
     expect(output.prompt).toContain('As a Senior Backend Developer, review the following code:');
     // Accept both raw and HTML-escaped codeSnippet
     const codeSnippetVariants = [

--- a/prompt-engine/src/engine/__tests__/generator.unit.test.ts
+++ b/prompt-engine/src/engine/__tests__/generator.unit.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import { generatePrompt, createTemplate } from '../generator';
+import { createVaultItem } from '../vault';
+
+jest.mock('../vault'); // Mock vault functions to avoid actual API calls
+(createVaultItem as any).mockResolvedValue({vaultId: 'test'});
 
 describe('generator module', () => {
   const template = createTemplate({
@@ -10,23 +14,23 @@ describe('generator module', () => {
     role: 'Dev'
   });
 
-  it('generates prompt with all fields', () => {
+  it('generates prompt with all fields', async () => {
     const context = { name: 'Alice', company: 'Acme' };
-    const result = generatePrompt(template, context);
+    const result = await generatePrompt(template, context);
     expect(result.prompt).toBe('Hello Alice from Acme');
     expect(result.missingFields).toEqual([]);
     expect(result.contextUsed).toEqual(['name', 'company']);
   });
 
-  it('detects missing fields', () => {
+  it('detects missing fields', async () => {
     const context = { name: 'Alice' };
-    const result = generatePrompt(template, context);
+    const result = await generatePrompt(template, context);
     expect(result.missingFields).toEqual(['company']);
   });
 
-  it('sanitizes context', () => {
+  it('sanitizes context', async () => {
     const context = { name: 'Alice {{evil}}', company: 'Acme' };
-    const result = generatePrompt(template, context);
+    const result = await generatePrompt(template, context);
     expect(result.prompt).toContain('Alice \\{\\{evil\\}\\}');
   });
 });

--- a/prompt-engine/src/engine/__tests__/integration.api.test.ts
+++ b/prompt-engine/src/engine/__tests__/integration.api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, jest } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import request from 'supertest';
 import express from 'express';
 import dotenv from 'dotenv';
@@ -7,9 +7,11 @@ import refineRoute from '../../routes/refine';
 import aiGenerateRoute from '../../routes/ai-generate';
 import { createTemplate } from '../generator';
 import { DEFAULT_OPENAI_CONFIG } from '../openai';
+import { createVaultItem, updateVaultItem } from '../vault';
 
 // Mock the refiner module functions
 jest.mock('../refiner');
+jest.mock('../vault');
 
 // Import the mocked module
 import { 
@@ -28,6 +30,7 @@ const mockGetPromptRefinementTypes = getPromptRefinementTypes as jest.MockedFunc
 const mockGetContentRefinementTypes = getContentRefinementTypes as jest.MockedFunction<typeof getContentRefinementTypes>;
 const mockPromptRefinerTools = promptRefinerTools as any;
 const mockContentRefinerTools = contentRefinerTools as any;
+const mockCreateVaultItem = createVaultItem as jest.MockedFunction<typeof createVaultItem>;
 
 // Configure the mocks for prompts with dynamic responses
 mockRefinePrompt.mockImplementation(async (prompt: string, refinementType: string = 'specific') => {
@@ -201,6 +204,7 @@ Object.defineProperty(mockContentRefinerTools, 'map', {
     }
   ])
 });
+(mockCreateVaultItem as any).mockResolvedValue({ vaultId: 'test'})
 
 dotenv.config({ path: '../../.env.example' });
 

--- a/prompt-engine/src/engine/__tests__/refiner.unit.test.ts
+++ b/prompt-engine/src/engine/__tests__/refiner.unit.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, jest } from '@jest/globals';
 import { refinePrompt, getRefinementTypes, refinerTools } from '../refiner';
 import { DEFAULT_OPENAI_CONFIG } from '../openai';
 import { generateAndRunPrompt } from '../generator';
+import { updateVaultItem } from '../vault';
 
 // Mock the generateAndRunPrompt to avoid actual API calls in unit tests
 jest.mock('../generator');
+jest.mock('../vault');
 
 const mockGeneratedResult = {
   prompt: 'Mock prompt',
@@ -18,6 +20,7 @@ const mockGeneratedResult = {
 
 // Import and set up the mock after the module is mocked
 (generateAndRunPrompt as any).mockResolvedValue(mockGeneratedResult);
+(updateVaultItem as any).mockResolvedValue({vaultId: 'test'});
 
 describe('refiner module', () => {
   describe('getRefinementTypes', () => {
@@ -76,7 +79,7 @@ describe('refiner module', () => {
         customApiKey: DEFAULT_OPENAI_CONFIG.apiKey
       };
 
-      const result = await refinePrompt(originalPrompt, 'specific', defaultModelConfig);
+      const result = await refinePrompt(originalPrompt, 'specific', 'test', defaultModelConfig);
       expect(result.refinedPrompt).toBe('This is a refined and improved prompt with better clarity.');
     });
 

--- a/prompt-engine/src/engine/__tests__/template.api.test.ts
+++ b/prompt-engine/src/engine/__tests__/template.api.test.ts
@@ -13,11 +13,10 @@ jest.mock('../template', () => ({
 	updatePromptTemplate: jest.fn(),
 	updateEmbeddings: jest.fn(),
 	deletePromptTemplate: jest.fn(),
-  getAllPromptTemplates: jest.fn(),
-  getPromptTemplateById: jest.fn(),
+	getAllPromptTemplates: jest.fn(),
+	getPromptTemplateById: jest.fn(),
 }))
 
-const PublicPromptTemplateModel = require('../../models/PromptTemplate')
 const {
 	createPromptTemplate,
 	updatePromptTemplate,

--- a/prompt-engine/src/engine/__tests__/vault.api.test.ts
+++ b/prompt-engine/src/engine/__tests__/vault.api.test.ts
@@ -1,0 +1,136 @@
+import request from 'supertest';
+import express from 'express';
+import { jest, describe, it, expect } from '@jest/globals';
+import vaultRoutes from '../../routes/vault';
+import { createVaultItem, getVaultItemById, getAllVaultItemsByUserId, updateVaultItem } from '../../engine/vault';
+
+jest.mock('../../engine/vault');
+
+const app = express();
+app.use(express.json());
+app.use('/vault', vaultRoutes);
+
+describe('Vault Routes', () => {
+  describe('POST /vault/add', () => {
+    it('should create a new VaultItem', async () => {
+      const mockData = {
+        userId: 'user123',
+        templateId: 'template456',
+        initialPrompt: 'Initial prompt',
+      };
+
+      (createVaultItem as jest.Mock<any>).mockResolvedValue({
+        ...mockData,
+        vaultId: 'vault123',
+      });
+
+      const response = await request(app).post('/vault/add').send(mockData);
+
+      expect(response.status).toBe(201);
+      expect(response.body).toEqual({
+        userId: 'user123',
+        templateId: 'template456',
+        initialPrompt: 'Initial prompt',
+        vaultId: 'vault123',
+      });
+      expect(createVaultItem).toHaveBeenCalledWith(mockData);
+    });
+
+    it('should return 500 if there is an error', async () => {
+      (createVaultItem as jest.Mock<any>).mockRejectedValue(new Error('Internal Server Error'));
+
+      const response = await request(app).post('/vault/add').send({
+        userId: 'user123',
+        templateId: 'template456',
+        initialPrompt: 'Initial prompt',
+      });
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ error: 'Internal Server Error' });
+    });
+  });
+
+  describe('GET /vault/:vaultId', () => {
+    it('should return a VaultItem by ID', async () => {
+      const mockData = { vaultId: 'vault123', userId: 'user123' };
+
+      (getVaultItemById as jest.Mock<any>).mockResolvedValue(mockData);
+
+      const response = await request(app).get('/vault/vault123');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(mockData);
+      expect(getVaultItemById).toHaveBeenCalledWith('vault123');
+    });
+
+    it('should return 404 if VaultItem not found', async () => {
+      (getVaultItemById as jest.Mock<any>).mockResolvedValue(null);
+
+      const response = await request(app).get('/vault/vault123');
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ message: 'VaultItem not found' });
+    });
+  });
+
+  describe('POST /vault/update', () => {
+    it('should update a VaultItem', async () => {
+      const mockData = { vaultId: 'vault123', refinedPrompt: 'Updated prompt' };
+
+      (updateVaultItem as jest.Mock<any>).mockResolvedValue(mockData);
+
+      const response = await request(app).post('/vault/update').send({
+        vaultId: 'vault123',
+        refinedPrompt: 'Updated prompt',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(mockData);
+      expect(updateVaultItem).toHaveBeenCalledWith('vault123', {
+        vaultId: 'vault123',
+        refinedPrompt: 'Updated prompt',
+      });
+    });
+
+    it('should return 400 if vaultId is missing', async () => {
+      const response = await request(app).post('/vault/update').send({
+        refinedPrompt: 'Updated prompt',
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ message: 'vaultId is required' });
+    });
+
+    it('should return 404 if VaultItem not found', async () => {
+      (updateVaultItem as jest.Mock<any>).mockResolvedValue(null);
+
+      const response = await request(app).post('/vault/update').send({
+        vaultId: 'vault123',
+        refinedPrompt: 'Updated prompt',
+      });
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ message: 'VaultItem not found' });
+    });
+  });
+
+  describe('GET /vault/user/:userId', () => {
+    it('should return all VaultItems for a user', async () => {
+      const mockData = [{ vaultId: 'vault123', userId: 'user123' }];
+
+      (getAllVaultItemsByUserId as jest.Mock<any>).mockResolvedValue(mockData);
+
+      const response = await request(app).get('/vault/user/user123');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(mockData);
+      expect(getAllVaultItemsByUserId).toHaveBeenCalledWith('user123');
+    });
+
+    it('should return 400 if userId is missing', async () => {
+      const response = await request(app).get('/vault/user/');
+
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/prompt-engine/src/engine/__tests__/vault.unit.test.ts
+++ b/prompt-engine/src/engine/__tests__/vault.unit.test.ts
@@ -1,0 +1,151 @@
+import { jest, describe, it, expect } from '@jest/globals';
+
+import { createVaultItem, getVaultItemById, getAllVaultItemsByUserId, updateVaultItem, deleteVaultItem, restoreVersion } from '../vault';
+import { VaultItemModel } from '../../models/Vault';
+import { VaultItem } from '../types';
+
+jest.mock('../../models/Vault');
+
+describe('Vault', () => {
+  describe('createVaultItem', () => {
+    it('should create a new VaultItem', async () => {
+      const mockData = {
+        userId: 'user123',
+        vaultId: 'vault123',
+        templateId: 'template456',
+        initialPrompt: 'Initial prompt',
+      };
+
+      (VaultItemModel.prototype.save as jest.Mock<any>).mockResolvedValue(mockData);
+
+      const result = await createVaultItem(mockData);
+      expect(result).toEqual(mockData);
+      expect(VaultItemModel.prototype.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('getVaultItemById', () => {
+    it('should return a VaultItem by vaultId', async () => {
+      const mockData = { vaultId: 'vault123', userId: 'user123' };
+      (VaultItemModel.findOne as jest.Mock<any>).mockResolvedValue(mockData);
+
+      const result = await getVaultItemById('vault123');
+      expect(result).toEqual(mockData);
+      expect(VaultItemModel.findOne).toHaveBeenCalledWith({ vaultId: 'vault123' });
+    });
+
+    it('should return null if VaultItem not found', async () => {
+      (VaultItemModel.findOne as jest.Mock<any>).mockResolvedValue(null);
+
+      const result = await getVaultItemById('vault123');
+      expect(result).toBeNull();
+      expect(VaultItemModel.findOne).toHaveBeenCalledWith({ vaultId: 'vault123' });
+    });
+  });
+
+  describe('getAllVaultItemsByUserId', () => {
+    it('should return all VaultItems for a user', async () => {
+      const mockData: VaultItem[] = [{
+          vaultId: 'vault123', userId: 'user123',
+          templateId: 'test-template',
+          initialPrompt: 'Initial prompt',
+          refinedPrompt: '',
+          generatedContent: '',
+          history: [],
+          createdAt: new Date(),
+          updatedAt: new Date()
+      }];
+      (VaultItemModel.find as jest.Mock<any>).mockResolvedValue(mockData);
+
+      const result = await getAllVaultItemsByUserId('user123');
+      expect(result).toEqual(mockData);
+      expect(VaultItemModel.find).toHaveBeenCalledWith({ userId: 'user123' });
+    });
+  });
+
+  describe('updateVaultItem', () => {
+    it('should update a VaultItem', async () => {
+      const mockData = { vaultId: 'vault123', refinedPrompt: 'Updated prompt' };
+      (VaultItemModel.findOne as jest.Mock<any>).mockResolvedValue({
+        ...mockData,
+        save: (jest.fn() as jest.Mock<any>).mockResolvedValue(mockData),
+      });
+
+      const result = await updateVaultItem('vault123', { refinedPrompt: 'Updated prompt' });
+      expect(result).toEqual({ ...mockData });
+      expect(VaultItemModel.findOne).toHaveBeenCalledWith({ vaultId: 'vault123' });
+    });
+
+    it('should return null if VaultItem not found', async () => {
+      (VaultItemModel.findOne as jest.Mock<any>).mockResolvedValue(null);
+
+      const result = await updateVaultItem('vault123', { refinedPrompt: 'Updated prompt' });
+      expect(result).toBeNull();
+      expect(VaultItemModel.findOne).toHaveBeenCalledWith({ vaultId: 'vault123' });
+    });
+  });
+
+  describe('deleteVaultItem', () => {
+    it('should delete a VaultItem', async () => {
+      const mockData = { vaultId: 'vault123' };
+      (VaultItemModel.findOneAndDelete as jest.Mock<any>).mockResolvedValue(mockData);
+
+      const result = await deleteVaultItem('vault123');
+      expect(result).toEqual(mockData);
+      expect(VaultItemModel.findOneAndDelete).toHaveBeenCalledWith({ vaultId: 'vault123' });
+    });
+
+    it('should return null if VaultItem not found', async () => {
+      (VaultItemModel.findOneAndDelete as jest.Mock<any>).mockResolvedValue(null);
+
+      const result = await deleteVaultItem('vault123');
+      expect(result).toBeNull();
+      expect(VaultItemModel.findOneAndDelete).toHaveBeenCalledWith({ vaultId: 'vault123' });
+    });
+  });
+
+  describe('restoreVersion', () => {
+    it('should restore a specific version of VaultItem', async () => {
+      const mockData = {
+        vaultId: 'vault123',
+        history: [
+          { version: 1, refinedPrompt: 'Old prompt', generatedContent: 'Old content' },
+          { version: 2, refinedPrompt: 'New prompt', generatedContent: 'New content' },
+        ],
+        save: (jest.fn() as jest.Mock<any>).mockResolvedValue({
+            vaultId: 'vault123',
+            refinedPrompt: 'Old prompt', 
+            generatedContent: 'Old content',
+            history: [
+              { version: 1, refinedPrompt: 'Old prompt', generatedContent: 'Old content' },
+              { version: 2, refinedPrompt: 'New prompt', generatedContent: 'New content' },
+            ],
+            save: (jest.fn() as jest.Mock<any>).mockResolvedValue(true),
+          }),
+      };
+
+      (VaultItemModel.findOne as jest.Mock<any>).mockResolvedValue(mockData);
+
+      const result = await restoreVersion('vault123', 1);
+      expect(result).not.toBeNull();
+      if (result) {
+        expect(result.refinedPrompt).toEqual('Old prompt');
+        expect(result.generatedContent).toEqual('Old content');
+      }
+      expect(VaultItemModel.findOne).toHaveBeenCalledWith({ vaultId: 'vault123' });
+    });
+
+    it('should return null if version not found', async () => {
+      const mockData = {
+        vaultId: 'vault123',
+        history: [{ version: 1, refinedPrompt: 'Old prompt', generatedContent: 'Old content' }],
+      };
+
+      (VaultItemModel.findOne as jest.Mock<any>).mockResolvedValue(mockData);
+
+      const result = await restoreVersion('vault123', 2);
+      expect(result).toBeNull();
+      expect(VaultItemModel.findOne).toHaveBeenCalledWith({ vaultId: 'vault123' });
+    });
+  });
+});

--- a/prompt-engine/src/engine/generator.ts
+++ b/prompt-engine/src/engine/generator.ts
@@ -1,6 +1,7 @@
 import Handlebars from 'handlebars';
 import type { PromptTemplate, PromptContext, PromptOutput, ModelConfig, PromptResult } from './types';
 import { OpenAIClient, createOpenAIClient, DEFAULT_OPENAI_CONFIG } from './openai';
+import { createVaultItem } from './vault';
 
 export function extractTemplateVariables(template: string): string[] {
   const variables = new Set<string>();
@@ -46,17 +47,25 @@ export function sanitizeContext(context: PromptContext): PromptContext {
   return sanitized;
 }
 
-export function generatePrompt(template: PromptTemplate, context: PromptContext): PromptOutput {
+export async function generatePrompt(template: PromptTemplate, context: PromptContext, userId: string = 'admin'): Promise<PromptOutput> {
   try {
     const missingFields = validateRequiredFields(template.requiredFields, context);
     const sanitizedContext = sanitizeContext(context);
     const compiledTemplate = Handlebars.compile(template.template);
     const prompt = compiledTemplate(sanitizedContext);
     const contextUsed = getUsedContextFields(template.template, sanitizedContext);
+
+    const { vaultId } = await createVaultItem({
+      userId: userId || 'admin',
+      templateId: template.id,
+      initialPrompt: prompt,
+    })
+
     return {
       prompt: prompt.trim(),
       missingFields,
       contextUsed,
+      vaultId: vaultId,
       metadata: {
         templateId: template.id,
         templateName: template.name,
@@ -69,6 +78,7 @@ export function generatePrompt(template: PromptTemplate, context: PromptContext)
       prompt: '',
       missingFields: template.requiredFields,
       contextUsed: [],
+      vaultId: '',
       metadata: {
         templateId: template.id,
         templateName: template.name,
@@ -86,7 +96,7 @@ export async function generateAndRunPrompt(
   modelConfig: ModelConfig
 ): Promise<PromptResult> {
   const startTime = Date.now();
-  const promptOutput = generatePrompt(template, context);
+  const promptOutput = await generatePrompt(template, context);
   if (promptOutput.missingFields.length > 0) {
     return {
       prompt: promptOutput.prompt,

--- a/prompt-engine/src/engine/generator.ts
+++ b/prompt-engine/src/engine/generator.ts
@@ -55,17 +55,21 @@ export async function generatePrompt(template: PromptTemplate, context: PromptCo
     const prompt = compiledTemplate(sanitizedContext);
     const contextUsed = getUsedContextFields(template.template, sanitizedContext);
 
-    const { vaultId } = await createVaultItem({
-      userId: userId || 'admin',
-      templateId: template.id,
-      initialPrompt: prompt,
-    })
-
+    let vaultId = '';
+    if (!(template.id === 'refine-prompt' || template.id === 'refine-content')) {
+      const result = await createVaultItem({
+        userId: userId || 'admin',
+        templateId: template.id,
+        initialPrompt: prompt,
+      });
+      vaultId = result.vaultId;
+    }
+    
     return {
       prompt: prompt.trim(),
       missingFields,
       contextUsed,
-      vaultId: vaultId,
+      vaultId: vaultId || undefined,
       metadata: {
         templateId: template.id,
         templateName: template.name,

--- a/prompt-engine/src/engine/refiner.ts
+++ b/prompt-engine/src/engine/refiner.ts
@@ -1,10 +1,12 @@
 import { generateAndRunPrompt, createTemplate } from './generator';
 import type { ModelConfig } from './types';
 import { DEFAULT_OPENAI_CONFIG } from './openai';
+import { updateVaultItem } from './vault';
 
 export async function refinePrompt(
   prompt: string,
   refinementType: string = 'specific',
+  vaultId?: string,
   modelConfig?: ModelConfig
 ): Promise<{
   refinedPrompt: string;
@@ -53,6 +55,13 @@ CRITICAL INSTRUCTIONS:
 
   const result = await generateAndRunPrompt(template, {}, config);
 
+  if (vaultId) {
+    // Update the vault item with the refined prompt
+    await updateVaultItem(vaultId, {
+      refinedPrompt: result.result.trim(),
+    });
+  }
+
   return {
     refinedPrompt: result.result.trim(),
     originalPrompt: prompt,
@@ -65,6 +74,7 @@ CRITICAL INSTRUCTIONS:
 export async function refineContent(
   content: string,
   refinementType: string = 'clarity',
+  vaultId?: string,
   modelConfig?: ModelConfig
 ): Promise<{
   refinedContent: string;
@@ -112,6 +122,13 @@ CRITICAL INSTRUCTIONS:
   });
 
   const result = await generateAndRunPrompt(template, {}, config);
+
+  if (vaultId) {
+    // Update the vault item with the refined prompt
+    await updateVaultItem(vaultId, {
+      generatedContent: result.result.trim(),
+    });
+  }
 
   return {
     refinedContent: result.result.trim(),

--- a/prompt-engine/src/engine/template.ts
+++ b/prompt-engine/src/engine/template.ts
@@ -13,7 +13,7 @@ function textFieldsForEmbedding(template: PromptTemplate) {
     ].filter(Boolean).join("\n");
 }
 
-export async function createPromptTemplate(data: PromptTemplate) {
+async function createPromptTemplate(data: PromptTemplate) {
     const inputText = textFieldsForEmbedding(data);
     const embedding = await getEmbedding(inputText);
 
@@ -27,7 +27,7 @@ export async function createPromptTemplate(data: PromptTemplate) {
     return await newTemplate.save();
 }
 
-export async function updatePromptTemplate(data: PromptTemplate) {
+async function updatePromptTemplate(data: PromptTemplate) {
     const inputText = textFieldsForEmbedding(data as PromptTemplate);
     const embedding = await getEmbedding(inputText);
   
@@ -44,7 +44,7 @@ export async function updatePromptTemplate(data: PromptTemplate) {
     return updated;
 }
 
-export const updateEmbeddings = async () => {
+async function updateEmbeddings () {
   const templates = await PublicPromptTemplateModel.find();
 
   console.log(`Found ${templates.length} templates to update.`);
@@ -73,15 +73,24 @@ export const updateEmbeddings = async () => {
   };
 };
 
-export async function getAllPromptTemplates() {
+async function getAllPromptTemplates() {
   return await PublicPromptTemplateModel.find();
 }
 
-export async function getPromptTemplateById(id: string) {
+async function getPromptTemplateById(id: string) {
   return await PublicPromptTemplateModel.findOne({ id });
 }
 
-export async function deletePromptTemplate(id: string) {
+async function deletePromptTemplate(id: string) {
   const deleted = await PublicPromptTemplateModel.findOneAndDelete({ id });
   return deleted;
+}
+
+export {
+  createPromptTemplate,
+  updatePromptTemplate,
+  updateEmbeddings,
+  getAllPromptTemplates,
+  getPromptTemplateById,
+  deletePromptTemplate
 }

--- a/prompt-engine/src/engine/types.ts
+++ b/prompt-engine/src/engine/types.ts
@@ -31,6 +31,7 @@ export type PromptOutput = {
   prompt: string;
   missingFields: string[];
   contextUsed: string[];
+  vaultId?: string;
   metadata?: Record<string, any>;
 };
 
@@ -78,5 +79,25 @@ export type TemplateFilter = {
   tags?: string[];
   search?: string;
 };
+
+export type VaultHistoryItem = {
+  refinedPrompt: string; 
+  generatedContent: string;
+  action: 'Refine Prompt' | 'Generate Content';
+  version: number;
+  updatedAt: Date;
+};
+
+export type VaultItem = {
+  userId: string;
+  vaultId: string;
+  templateId: string;
+  initialPrompt: string;
+  refinedPrompt: string;
+  generatedContent: string;
+  history: VaultHistoryItem[];
+  createdAt: Date;
+  updatedAt: Date;
+}
 
 export type RefinerAction = 'make-concise' | 'make-friendly' | 'make-formal' | 'add-examples' | 'simplify';

--- a/prompt-engine/src/engine/types.ts
+++ b/prompt-engine/src/engine/types.ts
@@ -92,10 +92,15 @@ export type VaultItem = {
   userId: string;
   vaultId: string;
   templateId: string;
+  name: string;
   initialPrompt: string;
   refinedPrompt: string;
   generatedContent: string;
   history: VaultHistoryItem[];
+  nameEmbedding?: number[];
+  initialPromptEmbedding?: number[];
+  refinedPromptEmbedding?: number[];
+  generatedContentEmbedding?: number[];
   createdAt: Date;
   updatedAt: Date;
 }

--- a/prompt-engine/src/engine/vault.ts
+++ b/prompt-engine/src/engine/vault.ts
@@ -1,0 +1,113 @@
+import { VaultItemModel } from '../models/Vault';
+import { VaultItem } from './types';
+
+async function createVaultItem(vaultItemData: Partial<VaultItem>) {
+    try {
+      const vaultItem = new VaultItemModel(vaultItemData);
+      await vaultItem.save();
+      console.log('VaultItem created:', vaultItem);
+      return vaultItem;
+    } catch (error) {
+      console.error('Error creating VaultItem:', error);
+      throw error;
+    }
+  }
+
+async function getVaultItemById(vaultId: string) {
+    try {
+      const vaultItem = await VaultItemModel.findOne({ vaultId });
+      if (vaultItem) {
+        console.log('VaultItem found:', vaultItem);
+        return vaultItem;
+      } else {
+        console.log('VaultItem not found');
+        return null;
+      }
+    } catch (error) {
+      console.error('Error fetching VaultItem:', error);
+      throw error;
+    }
+}
+
+async function getAllVaultItemsByUserId(userId: string = 'admin') {
+    try {
+      const vaultItems = await VaultItemModel.find({ userId });
+      console.log('All VaultItems:', vaultItems);
+      return vaultItems;
+    } catch (error) {
+      console.error('Error fetching VaultItems:', error);
+      throw error;
+    }
+}
+
+async function updateVaultItem(vaultId: string, updates: Partial<VaultItem>) {
+    try {
+      const vaultItem = await VaultItemModel.findOne({ vaultId });
+  
+      if (!vaultItem) {
+        console.log('VaultItem not found');
+        return null;
+      }
+  
+      Object.assign(vaultItem, updates);
+      vaultItem.updatedAt = new Date();
+  
+      await vaultItem.save(); 
+      console.log('VaultItem updated:', vaultItem);
+
+      return vaultItem;
+    } catch (error) {
+      console.error('Error updating VaultItem:', error);
+      throw error;
+    }
+  }
+
+async function deleteVaultItem(vaultId: string) {
+    try {
+      const deletedItem = await VaultItemModel.findOneAndDelete({ vaultId });
+      if (deletedItem) {
+        console.log('VaultItem deleted:', deletedItem);
+        return deletedItem;
+      } else {
+        console.log('VaultItem not found');
+        return null;
+      }
+    } catch (error) {
+      console.error('Error deleting VaultItem:', error);
+      throw error;
+    }
+}
+
+async function restoreVersion(vaultId: string, version: number) {
+    try {
+      const vaultItem = await VaultItemModel.findOne({ vaultId });
+      if (vaultItem) {
+        const targetVersion = vaultItem.history.find((entry) => entry.version === version);
+        if (targetVersion) {
+          vaultItem.refinedPrompt = targetVersion.refinedPrompt;
+          vaultItem.generatedContent = targetVersion.generatedContent;
+          await vaultItem.save();
+          console.log(`Restored VaultItem to version ${version}:`, vaultItem);
+          return vaultItem;
+        } else {
+          console.log(`Version ${version} not found for VaultItem`);
+          return null;
+        }
+      } else {
+        console.log('VaultItem not found');
+        return null;
+      }
+    } catch (error) {
+      console.error('Error restoring VaultItem version:', error);
+      throw error;
+    }
+}
+
+export {
+    createVaultItem,
+    getVaultItemById,
+    getAllVaultItemsByUserId,
+    updateVaultItem,
+    deleteVaultItem,
+    restoreVersion
+}

--- a/prompt-engine/src/engine/vault.ts
+++ b/prompt-engine/src/engine/vault.ts
@@ -4,9 +4,8 @@ import { VaultItem } from './types';
 async function createVaultItem(vaultItemData: Partial<VaultItem>) {
     try {
       const vaultItem = new VaultItemModel(vaultItemData);
-      await vaultItem.save();
       console.log('VaultItem created:', vaultItem);
-      return vaultItem;
+      return await vaultItem.save();
     } catch (error) {
       console.error('Error creating VaultItem:', error);
       throw error;
@@ -51,11 +50,8 @@ async function updateVaultItem(vaultId: string, updates: Partial<VaultItem>) {
   
       Object.assign(vaultItem, updates);
       vaultItem.updatedAt = new Date();
-  
-      await vaultItem.save(); 
-      console.log('VaultItem updated:', vaultItem);
 
-      return vaultItem;
+      return await vaultItem.save();
     } catch (error) {
       console.error('Error updating VaultItem:', error);
       throw error;
@@ -86,9 +82,8 @@ async function restoreVersion(vaultId: string, version: number) {
         if (targetVersion) {
           vaultItem.refinedPrompt = targetVersion.refinedPrompt;
           vaultItem.generatedContent = targetVersion.generatedContent;
-          await vaultItem.save();
           console.log(`Restored VaultItem to version ${version}:`, vaultItem);
-          return vaultItem;
+          return await vaultItem.save();
         } else {
           console.log(`Version ${version} not found for VaultItem`);
           return null;

--- a/prompt-engine/src/models/Vault.ts
+++ b/prompt-engine/src/models/Vault.ts
@@ -1,0 +1,54 @@
+import mongoose from 'mongoose';
+
+import { VaultItem } from '../engine/types';
+
+const vaultItemSchema = new mongoose.Schema<VaultItem>({
+    userId: { type: String, required: true, default: 'admin' },
+    vaultId: { type: String, required: true },
+    templateId: { type: String, required: true },
+    initialPrompt: { type: String, required: true },
+    refinedPrompt: { type: String },
+    generatedContent: { type: String },
+    history: [
+        {
+          refinedPrompt: { type: String },
+          generatedContent: { type: String },
+          action: { type: String, enum: ['Refine Prompt', 'Generate Content'], required: true },
+          version: { type: Number, required: true },
+          updatedAt: { type: Date, default: Date.now },
+        },
+    ],
+    createdAt: { type: Date, default: Date.now },
+    updatedAt: { type: Date, default: Date.now },
+
+});
+
+vaultItemSchema.pre('save', async function (next) {
+    if (this.isNew && !this.vaultId) {
+      const count = await mongoose.model('VaultItem').countDocuments({ userId: this.userId });
+      this.vaultId = `${this.userId}-${count + 1}`; // Auto-create `vaultId` with format `{userId}-{generated number}`
+    }
+
+    if (!this.isNew) {
+        const latestVersion = this.history.length > 0 ? this.history[this.history.length - 1].version : 0;
+    
+        if (this.isModified('refinedPrompt') || this.isModified('generatedContent')) {
+          this.history.push({
+              refinedPrompt: this.refinedPrompt,
+              generatedContent: this.generatedContent,
+              action: this.isModified('refinedPrompt') ? 'Refine Prompt' : 'Generate Content',
+              version: latestVersion + 1,
+              updatedAt: new Date(),
+          });
+    
+          // Limit history to last 20 versions
+          if (this.history.length > 20) {
+            this.history.shift();
+          }
+        }
+      }
+    next();
+});
+
+export const VaultItemModel = mongoose.model<VaultItem>('VaultItem', vaultItemSchema, 'vault_items');
+

--- a/prompt-engine/src/models/Vault.ts
+++ b/prompt-engine/src/models/Vault.ts
@@ -4,7 +4,7 @@ import { VaultItem } from '../engine/types';
 
 const vaultItemSchema = new mongoose.Schema<VaultItem>({
     userId: { type: String, required: true, default: 'admin' },
-    vaultId: { type: String, required: true },
+    vaultId: { type: String }, // will be auto-generated
     templateId: { type: String, required: true },
     initialPrompt: { type: String, required: true },
     refinedPrompt: { type: String },

--- a/prompt-engine/src/models/Vault.ts
+++ b/prompt-engine/src/models/Vault.ts
@@ -6,6 +6,7 @@ const vaultItemSchema = new mongoose.Schema<VaultItem>({
     userId: { type: String, required: true, default: 'admin' },
     vaultId: { type: String }, // will be auto-generated
     templateId: { type: String, required: true },
+    name: { type: String },
     initialPrompt: { type: String, required: true },
     refinedPrompt: { type: String },
     generatedContent: { type: String },
@@ -18,6 +19,10 @@ const vaultItemSchema = new mongoose.Schema<VaultItem>({
           updatedAt: { type: Date, default: Date.now },
         },
     ],
+    nameEmbedding: { type: [Number], default: [] }, // TODO: for vault: searching
+    initialPromptEmbedding: { type: [Number], default: [] }, // for initial: searching
+    refinedPromptEmbedding: { type: [Number], default: [] }, // for refined: searching
+    generatedContentEmbedding: { type: [Number], default: [] }, // for content: searching
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now },
 
@@ -50,5 +55,6 @@ vaultItemSchema.pre('save', async function (next) {
     next();
 });
 
-export const VaultItemModel = mongoose.model<VaultItem>('VaultItem', vaultItemSchema, 'vault_items');
+const VaultItemModel = mongoose.model<VaultItem>('VaultItem', vaultItemSchema, 'vault_items');
 
+export default VaultItemModel;

--- a/prompt-engine/src/routes/ai-generate.ts
+++ b/prompt-engine/src/routes/ai-generate.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import { createOpenAIClient, DEFAULT_OPENAI_CONFIG } from "../engine/openai";
 import type { ModelConfig } from "../engine/types";
+import { updateVaultItem } from "../engine/vault";
 
 const router = Router();
 
@@ -102,7 +103,7 @@ const router = Router();
  *               $ref: '#/components/schemas/Error'
  */
 router.post("/", async (req: Request, res: Response) => {
-  const { text, modelConfig, systemPrompt } = req.body;
+  const { text, vaultId, modelConfig, systemPrompt } = req.body;
 
   if (typeof text !== "string" || !text.trim()) {
     return res.status(400).json({ error: "Missing or invalid text - must be a non-empty string" });
@@ -148,6 +149,12 @@ router.post("/", async (req: Request, res: Response) => {
     });
 
     const latencyMs = Date.now() - startTime;
+
+    if (vaultId) {
+      await updateVaultItem(vaultId, {
+        generatedContent: completion.content,
+      });
+    }
 
     res.json({
       text: text.trim(),

--- a/prompt-engine/src/routes/generate.ts
+++ b/prompt-engine/src/routes/generate.ts
@@ -52,7 +52,7 @@ const router = Router();
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-router.post("/", (req: Request, res: Response) => {
+router.post("/", async (req: Request, res: Response) => {
   const { template, context } = req.body;
   if (!template || typeof template !== "object" || !template.template) {
     return res.status(400).json({ error: "Missing or invalid template" });
@@ -78,7 +78,7 @@ router.post("/", (req: Request, res: Response) => {
       updatedAt: new Date(),
     };
 
-    const output = generatePrompt(promptTemplate, context as PromptContext);
+    const output = await generatePrompt(promptTemplate, context as PromptContext);
     res.json(output);
   } catch (err) {
     res.status(500).json({ error: err instanceof Error ? err.message : "Internal error" });

--- a/prompt-engine/src/routes/refine.ts
+++ b/prompt-engine/src/routes/refine.ts
@@ -186,7 +186,7 @@ router.get("/types", (req: Request, res: Response) => {
  */
 // POST /refine/prompt - Refine a prompt using AI
 router.post("/prompt", async (req: Request, res: Response) => {
-  const { prompt, refinementType = "specific", modelConfig } = req.body;
+  const { prompt, refinementType = "specific", vaultId, modelConfig } = req.body;
 
   if (typeof prompt !== "string") {
     return res.status(400).json({ error: "Missing or invalid prompt" });
@@ -201,7 +201,7 @@ router.post("/prompt", async (req: Request, res: Response) => {
   }
 
   try {
-    const result = await refinePrompt(prompt, refinementType, modelConfig as ModelConfig);
+    const result = await refinePrompt(prompt, refinementType, vaultId, modelConfig as ModelConfig);
     res.json(result);
   } catch (err) {
     if (err instanceof Error && err.message.includes("Unknown prompt refinement type")) {
@@ -287,7 +287,7 @@ router.post("/prompt", async (req: Request, res: Response) => {
  */
 // POST /refine/content - Refine content using AI
 router.post("/content", async (req: Request, res: Response) => {
-  const { content, refinementType = "clarity", modelConfig } = req.body;
+  const { content, refinementType = "clarity", vaultId, modelConfig } = req.body;
 
   if (typeof content !== "string") {
     return res.status(400).json({ error: "Missing or invalid content" });
@@ -302,7 +302,7 @@ router.post("/content", async (req: Request, res: Response) => {
   }
 
   try {
-    const result = await refineContent(content, refinementType, modelConfig as ModelConfig);
+    const result = await refineContent(content, refinementType, vaultId,  modelConfig as ModelConfig);
     res.json(result);
   } catch (err) {
     if (err instanceof Error && err.message.includes("Unknown content refinement type")) {

--- a/prompt-engine/src/routes/vault.ts
+++ b/prompt-engine/src/routes/vault.ts
@@ -1,0 +1,207 @@
+import express, { Request, Response } from 'express';
+import { createVaultItem, getVaultItemById, getAllVaultItemsByUserId, updateVaultItem } from '../engine/vault';
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * /vault:
+ *   post:
+ *     summary: Create a new vault item
+ *     description: Creates a new vault item with the provided data
+ *     tags: [Vault]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               userId:
+ *                 type: string
+ *                 description: The ID of the user creating the vault item
+ *               templateId:
+ *                 type: string
+ *                 description: The ID of the template associated with the vault item
+ *               initialPrompt:
+ *                 type: string
+ *                 description: The initial prompt for the vault item
+ *     responses:
+ *       201:
+ *         description: Successfully created vault item
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ */
+router.post('/add', async (req: Request, res: Response) => {
+  try {
+    const vaultItem = await createVaultItem(req.body);
+    res.status(201).json(vaultItem);
+  } catch (error : any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * @swagger
+ * /vault/{vaultId}:
+ *   get:
+ *     summary: Get a vault item by ID
+ *     description: Retrieves a vault item by its ID
+ *     tags: [Vault]
+ *     parameters:
+ *       - in: path
+ *         name: vaultId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the vault item to retrieve
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved vault item
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ */
+router.get('/:vaultId', async (req: Request, res: Response) => {
+  try {
+    const vaultItem = await getVaultItemById(req.params.vaultId);
+    if (vaultItem) {
+      res.status(200).json(vaultItem);
+    } else {
+      res.status(404).json({ message: 'VaultItem not found' });
+    }
+  } catch (error : any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * @swagger
+ * /vault/{vaultId}:
+ *   put:
+ *     summary: Update a vault item
+ *     description: Updates an existing vault item with the provided data
+ *     tags: [Vault]
+ *     parameters:
+ *       - in: path
+ *         name: vaultId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the vault item to update
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               refinedPrompt:
+ *                 type: string
+ *                 description: The refined prompt for the vault item
+ *               generatedContent:
+ *                 type: string
+ *                 description: The generated content for the vault item
+ *     responses:
+ *       200:
+ *         description: Successfully updated vault item
+ */
+router.post('/update', async (req: Request, res: Response) => {
+  try {
+    if (!req.body.vaultId) {
+      return res.status(400).json({ message: 'vaultId is required' });
+    }
+    if (!req.body.refinedPrompt && !req.body.generatedContent) {
+      return res.status(400).json({ message: 'At least one of refinedPrompt or generatedContent is required' });
+    }
+    const { vaultId } = req.body;
+    const updatedVaultItem = await updateVaultItem(vaultId, req.body);
+    if (updatedVaultItem) {
+      res.status(200).json(updatedVaultItem);
+    } else {
+      res.status(404).json({ message: 'VaultItem not found' });
+    }
+  } catch (error : any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * @swagger
+ * /vault/user:
+ *   post:
+ *     summary: Create a vault item for a specific user
+ *     description: Creates a new vault item associated with a specific user
+ *     tags: [Vault]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               userId:
+ *                 type: string
+ *                 description: The ID of the user creating the vault item
+ *               templateId:
+ *                 type: string
+ *                 description: The ID of the template associated with the vault item
+ *               initialPrompt:
+ *                 type: string
+ *                 description: The initial prompt for the vault item
+ *     responses:
+ *       201:
+ *         description: Successfully created vault item
+ */
+router.post('/user', async (req: Request, res: Response) => {
+    try {
+      const { userId, templateId, initialPrompt } = req.body;
+  
+      if (!userId || !templateId || !initialPrompt) {
+        return res.status(400).json({ message: 'userId, templateId, and initialPrompt are required' });
+      }
+  
+      const vaultItem = await createVaultItem(req.body);
+      res.status(201).json(vaultItem);
+    } catch (error: any) {
+      res.status(500).json({ error: error.message });
+    }
+});
+  
+/**
+ * @swagger
+ * /vault/user/{userId}:
+ *   get:
+ *     summary: Get all vault items for a specific user
+ *     description: Retrieves all vault items associated with a specific user
+ *     tags: [Vault]
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the user whose vault items are being retrieved
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved vault items
+ */
+router.get('/user/:userId', async (req: Request, res: Response) => {
+    try {
+      const { userId } = req.params;
+  
+      if (!userId) {
+        return res.status(400).json({ message: 'userId is required' });
+      }
+  
+      const vaultItems = await getAllVaultItemsByUserId(userId);
+      res.status(200).json(vaultItems);
+    } catch (error: any) {
+      res.status(500).json({ error: error.message });
+    }
+});
+
+export default router;


### PR DESCRIPTION
After user generate a prompt from templates, a vault will be created, we can consider it's data for an session.
Vaults are stored as an obj contains initial `generated prompt`, `refined prompt`, `generated content`. 
`Refined prompt` & `Generated content` are also stored as versions (represent each user's action) in history field.

**Flow:**
User generate prompt -> Create vault with `initialPrompt`, return `vaultId` to frontend
User refine prompt or generate/refine content -> update vault with coresponding field (`refinedPrompt` or `generatedContent`), also update `history` as a new version with that field and action (`refine-prompt` or `generate-content`)

<img width="1009" height="724" alt="image" src="https://github.com/user-attachments/assets/d2dedf91-a599-42ec-9f41-d9688c6c9545" />
